### PR TITLE
ci: test not running ci workflow on pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
-on: [ push, pull_request ]
+on:
+  push:
+    # Avoid multiple runs because release.yml workflow calls this workflow on push to main
+    branches_ignore:
+      - main
+  pull request:
+  workflow_call:
 defaults:
   run:
     shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     # Avoid multiple runs because release.yml workflow calls this workflow on push to main
     branches_ignore:
-      - main
+      - test-release
   pull request:
   workflow_call:
 defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     # Avoid multiple runs because release.yml workflow calls this workflow on push to main
     branches_ignore:
       - test-release
-  pull request:
+  pull_request:
   workflow_call:
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
     # Avoid multiple runs because release.yml workflow calls this workflow on push to main
     branches_ignore:
       - test-release
-  pull_request:
   workflow_call:
 defaults:
   run:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,10 +5,11 @@ on:
     # Avoid multiple runs because release.yml workflow calls this workflow on push to main
     branches:
     - '!main'
+    - '!test-release'
     - 'next'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main, next ]
+    branches: [ main, next, test-release ]
   schedule:
     - cron: '16 3 * * 1'
   workflow_call:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,12 +2,16 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, next ]
+    # Avoid multiple runs because release.yml workflow calls this workflow on push to main
+    branches:
+    - '!main'
+    - 'next'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main, next ]
   schedule:
     - cron: '16 3 * * 1'
+  workflow_call:
 
 jobs:
   analyze:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -12,6 +12,10 @@ jobs:
   analyze:
     name: Analyze
     uses: ./.github/workflows/codeql-analysis.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
   reuse:
     name: Reuse Workflows

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -2,7 +2,7 @@ name: Reuse
 on:
   push:
     branches:
-      - main
+      - test-release
 
 jobs:
   ci:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,30 @@
+name: Reuse
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+
+  analyze:
+    name: Analyze
+    uses: ./.github/workflows/codeql-analysis.yml
+
+  reuse:
+    name: Reuse Workflows
+    needs: [ ci, analyze ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test run
+        run: echo "This is a test run"
+
+      - name: Download compiled files
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          
+      - name: List downloaded files
+        run: ls -R


### PR DESCRIPTION
This PR tests removing `pull_request` trigger on CI workflow to see if it avoids duplicate runs

